### PR TITLE
docs(about): 𝕏ool の説明を実装に合わせて修正

### DIFF
--- a/src/content/spec/about.md
+++ b/src/content/spec/about.md
@@ -41,7 +41,7 @@ Slack / GitHub / GitLab / Backlog / Jira / OpenProject / Redmine の API ログ�
 
 ### [𝕏ool](https://x.doany.io/)
 
-𝕏 の OAuth 2.0 を利用し、Webhook からポストを作成できるウェブアプリです。SvelteKit と SQLite で SSR 構成にしてあります。
+𝕏 に OAuth 2.0 で連携し、その日に自分が投稿したポストのいいね・リポスト・インプレッションなどを集計して、通信簿として毎日自動でポストするウェブアプリです。LGTM 画像の生成とホスティングも同じデプロイで兼ねています。SvelteKit と SQLite で SSR 構成にしてあります。
 
 ### [cheaper-gs-map](https://5ym.github.io/cheaper-gs-map/)
 


### PR DESCRIPTION
about ページの 𝕏ool の説明が実装と食い違っていたので直します。

「Webhook からポストを作成できるウェブアプリ」と書いてありますが、xool に webhook の
受け口はありません。ルートは `api/cb` / `api/gh/*` / `api/health` / `api/oauth` /
`api/summary` / `api/summary/now` / `images/*` / `lgtm/*` だけです。

実際には自分の 1 日分のポストを JST で集計して `#ポスト通信簿` として自動投稿するツール
なので、そのように書き直しました。あわせて、同じデプロイが LGTM 側のホスト名も兼ねている
ことを 1 文足しています。

リポジトリ側の説明文と README も同様に直してあります (danything/xool)。
